### PR TITLE
fix: seed Signup email template in InitialSchema migration

### DIFF
--- a/Tickflo.Core/Migrations/20260427174645_InitialSchema.cs
+++ b/Tickflo.Core/Migrations/20260427174645_InitialSchema.cs
@@ -726,6 +726,14 @@ public partial class InitialSchema : Migration
             table: "workspaces",
             column: "slug",
             unique: true);
+
+        migrationBuilder.InsertData(
+            table: "email_templates",
+            columns: ["template_type_id", "version", "subject", "body", "created_at"],
+            values: [1, 0,
+                "Welcome to Tickflo — Confirm your email address",
+                "Hi,\n\nThanks for creating your Tickflo account! Please confirm your email address to get started.\n\n{{confirmation_link}}\n\nThis confirmation link will expire soon. If you did not sign up for Tickflo, please ignore this email.\n\nThanks,\nThe Tickflo Team",
+                new DateTime(2026, 4, 27, 0, 0, 0, 0, DateTimeKind.Utc) ]);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Problem

User registration (POST /signup) throws `InvalidOperationException: No email template found for type Signup` on any database that has not been manually seeded. Affects all fresh deployments.

## Root cause

`AuthenticationService.SendEmailConfirmationAsync()` queries `email_templates` for `template_type_id = 1` — no seed data existed for this row, so the query returns null and throws.

## Fix

Add the Signup email template as seed data in the `InitialSchema` migration using `migrationBuilder.InsertData()`. This runs exactly once — when the migration is first applied on a fresh database — not on every container startup.

## Testing

- **Fresh database:** migration creates the schema and seeds the template → registration works
- **Existing database with manual seed:** migration already applied, no-op
- **Existing database without seed:** run `dotnet ef database update` or let `MigrateAsync()` apply any pending migrations (no-op since this is a migration edit, not a new migration — existing databases already have it applied)