### PR TITLE
fix: add recipient_name to signup email template vars

### DIFF
--- a/Tickflo.Core/Services/Authentication/AuthenticationService.cs
+++ b/Tickflo.Core/Services/Authentication/AuthenticationService.cs
@@ -170,7 +170,8 @@ public partial class AuthenticationService(
             EmailTemplateType.Signup,
             new Dictionary<string, string>
             {
-                { "confirmation_link", confirmationLink }
+                { "confirmation_link", confirmationLink },
+                { "recipient_name", user.Name },
             });
     }
 


### PR DESCRIPTION
## Summary

The signup email confirmation template uses `{{recipient_name}}` in its body (e.g. `Hi {{recipient_name}},`) but the caller in `AuthenticationService.SendEmailConfirmationAsync` was only passing `confirmation_link` in the template variables dictionary. This caused the template placeholder to render as raw text (`Hi {{recipient_name}},`) in outgoing emails.

## Fix

Added `recipient_name` to the vars dict, using `user.Name` which is `[Required]` on the Signup form.

**File:** `Tickflo.Core/Services/Authentication/AuthenticationService.cs:175`

```diff
- { "confirmation_link", confirmationLink }
+ { "confirmation_link", confirmationLink },
+ { "recipient_name", user.Name },
```

## Verification

- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — all 3 existing `AuthenticationServiceEmailConfirmation` tests pass
- Other email call sites (`PasswordResetRequestService`, `UserInvitationService`, `NotificationTriggerService`) already pass `recipient_name` (or `name` for invitation templates) correctly.

## Related

This was discovered while testing the batch email cron job. Emails queued before this fix and already marked `sent` will still have the raw `{{recipient_name}}` in their body — but going forward all new signups will render correctly.