### PR TITLE
Fix password reset link 404 (route mismatch) and HTTP scheme

### DIFF
--- a/Tickflo.Web/Pages/ResetPassword.cshtml
+++ b/Tickflo.Web/Pages/ResetPassword.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "/reset-password"
 @model Tickflo.Web.Pages.ResetPasswordModel
 @{
     ViewData["Title"] = "Reset password";

--- a/Tickflo.Web/Services/RequestOriginService.cs
+++ b/Tickflo.Web/Services/RequestOriginService.cs
@@ -11,12 +11,18 @@ public class RequestOriginService(IHttpContextAccessor httpContextAccessor, Tick
 
     public string GetCurrentOrigin()
     {
-        var request = this.httpContextAccessor.HttpContext?.Request;
-        if (request == null || !request.Host.HasValue || string.IsNullOrWhiteSpace(request.Scheme))
+        // Always prefer the configured BaseUrl — it is authoritative (and correct behind a TLS-terminating proxy)
+        if (!string.IsNullOrWhiteSpace(this.config.BaseUrl))
         {
-            return this.config.BaseUrl?.TrimEnd('/') ?? "";
+            return this.config.BaseUrl.TrimEnd('/');
         }
 
-        return $"{request.Scheme}://{request.Host}";
+        var request = this.httpContextAccessor.HttpContext?.Request;
+        if (request != null && request.Host.HasValue && !string.IsNullOrWhiteSpace(request.Scheme))
+        {
+            return $"{request.Scheme}://{request.Host}";
+        }
+
+        return "";
     }
 }


### PR DESCRIPTION
## Root Cause

The password reset link in emails was generating a 404 white screen because:

### 1. Route mismatch
`ResetPassword.cshtml` had `@page` (no route), so the convention-based route was `/ResetPassword`. The email link uses `/reset-password`. → **404 with empty body = white screen.**

### 2. HTTP scheme
`RequestOriginService.GetCurrentOrigin()` was reading `request.Scheme`, which is `http` behind the TLS-terminating nginx proxy. All generated links used `http://tickflo.co` instead of the configured `BaseUrl` (`https://tickflo.co`).

## Fixes
- Add explicit `@page "/reset-password"` route to `ResetPassword.cshtml`
- Prefer the configured `BaseUrl` in `RequestOriginService` when it exists (it's the authoritative value)

## Testing
Pushed to `dev` and auto-deployed to stage. Merge to `master` to ship to production.