### PR TITLE
fix: accept Mailgun form-urlencoded POSTs (drop Consumes filter)

### DIFF
--- a/Tickflo.Web/Controllers/InboundEmailController.cs
+++ b/Tickflo.Web/Controllers/InboundEmailController.cs
@@ -35,7 +35,6 @@ public class InboundEmailController(
     /// not returned to the caller to prevent Mailgun retries on expected failures.
     /// </summary>
     [HttpPost]
-    [Consumes("multipart/form-data")]
     public async Task<IActionResult> Receive()
     {
         InboundEmailPayload payload;


### PR DESCRIPTION
## Problem

Mailgun's  webhook log shows HTTP 415 for emails sent to inbound.tickflo.co:

```json
"code": 415,
"message": "Unsupported Media Type"
```

Mailgun sends `application/x-www-form-urlencoded` for emails **without** attachments and `multipart/form-data` only when files are present. The `[Consumes("multipart/form-data")]` attribute rejects plain emails at the framework level before they reach the controller.

## Fix

Remove the `[Consumes("multipart/form-data")]` attribute. The controller reads all data from `this.Request.Form` which ASP.NET Core handles transparently for both content types. No code changes needed in the parsing logic.

## Verification

- Build: 0 warnings, 0 errors
- Tests: 98/98 pass
- Format: clean