### PR TITLE
Release: fix Mailgun webhook 415 error (content-type)

### DIFF
--- a/Tickflo.Web/Controllers/InboundEmailController.cs
+++ b/Tickflo.Web/Controllers/InboundEmailController.cs
@@ -35,7 +35,6 @@ public class InboundEmailController(
     /// not returned to the caller to prevent Mailgun retries on expected failures.
     /// </summary>
     [HttpPost]
-    [Consumes("multipart/form-data")]
     public async Task<IActionResult> Receive()
     {
         InboundEmailPayload payload;


### PR DESCRIPTION
## Summary

One fix: drop the `[Consumes("multipart/form-data")]` filter on the inbound email endpoint.

Mailgun sends `application/x-www-form-urlencoded` for emails without attachments, which was rejected with HTTP 415 before the controller ever saw the request. The endpoint already reads from `Request.Form` which works with both content types.

## Verification
- Build: 0/0
- Tests: 98/98 pass
- Format: clean