### PR TITLE
fix: rate limiting middleware + ForbiddenException in WorkspaceAccessService (#161, #160)

### DIFF
--- a/Tickflo.Core/Services/Workspace/WorkspaceAccessService.cs
+++ b/Tickflo.Core/Services/Workspace/WorkspaceAccessService.cs
@@ -3,6 +3,7 @@ namespace Tickflo.Core.Services.Workspace;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Tickflo.Core.Data;
+using Tickflo.Core.Exceptions;
 
 /// <summary>
 /// Implementation of IWorkspaceAccessService.
@@ -247,7 +248,7 @@ public class WorkspaceAccessService(TickfloDbContext dbContext) : IWorkspaceAcce
         var isAdmin = await this.UserIsWorkspaceAdminAsync(userId, workspaceId);
         if (!isAdmin)
         {
-            throw new UnauthorizedAccessException(string.Format(null, UserNotAdminErrorFormat, userId, workspaceId));
+            throw new ForbiddenException(string.Format(null, UserNotAdminErrorFormat, userId, workspaceId));
         }
     }
 
@@ -256,7 +257,7 @@ public class WorkspaceAccessService(TickfloDbContext dbContext) : IWorkspaceAcce
         var hasAccess = await this.UserHasAccessAsync(userId, workspaceId);
         if (!hasAccess)
         {
-            throw new UnauthorizedAccessException(string.Format(null, UserNoAccessErrorFormat, userId, workspaceId));
+            throw new ForbiddenException(string.Format(null, UserNoAccessErrorFormat, userId, workspaceId));
         }
     }
 

--- a/Tickflo.Web/Middleware/RateLimitMiddleware.cs
+++ b/Tickflo.Web/Middleware/RateLimitMiddleware.cs
@@ -6,9 +6,9 @@ using System.Collections.Concurrent;
 /// Simple in-memory rate limiting middleware for auth endpoints.
 /// Tracks requests per IP per endpoint with a fixed window.
 /// </summary>
-public class RateLimitMiddleware
+public class RateLimitMiddleware(RequestDelegate next)
 {
-    private readonly RequestDelegate next;
+    private readonly RequestDelegate next = next;
     private static readonly ConcurrentDictionary<string, RateLimitEntry> Buckets = new();
     private const int MaxRequests = 10;
     private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
@@ -25,11 +25,6 @@ public class RateLimitMiddleware
         "/email-confirmation/confirm",
         "/email-confirmation/resend"
     ];
-
-    public RateLimitMiddleware(RequestDelegate next)
-    {
-        this.next = next;
-    }
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -87,7 +82,7 @@ public class RateLimitMiddleware
         return false;
     }
 
-    private class RateLimitEntry
+    private sealed class RateLimitEntry
     {
         public DateTime WindowStart { get; set; }
         public int Count { get; set; }

--- a/Tickflo.Web/Middleware/RateLimitMiddleware.cs
+++ b/Tickflo.Web/Middleware/RateLimitMiddleware.cs
@@ -1,0 +1,95 @@
+namespace Tickflo.Web.Middleware;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Simple in-memory rate limiting middleware for auth endpoints.
+/// Tracks requests per IP per endpoint with a fixed window.
+/// </summary>
+public class RateLimitMiddleware
+{
+    private readonly RequestDelegate next;
+    private static readonly ConcurrentDictionary<string, RateLimitEntry> Buckets = new();
+    private const int MaxRequests = 10;
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+
+    // Auth-related paths that should be rate-limited
+    private static readonly string[] AuthPaths =
+    [
+        "/login",
+        "/signup",
+        "/forgot-password",
+        "/reset-password",
+        "/set-password",
+        "/api/send-emails",
+        "/email-confirmation/confirm",
+        "/email-confirmation/resend"
+    ];
+
+    public RateLimitMiddleware(RequestDelegate next)
+    {
+        this.next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.Value?.ToLowerInvariant();
+
+        if (path != null && PathRequiresRateLimiting(path))
+        {
+            var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var key = $"{ip}:{path}";
+            var now = DateTime.UtcNow;
+
+            var entry = Buckets.GetOrAdd(key, _ => new RateLimitEntry { WindowStart = now, Count = 0 });
+            var blocked = false;
+
+            lock (entry)
+            {
+                if (now - entry.WindowStart > Window)
+                {
+                    entry.WindowStart = now;
+                    entry.Count = 0;
+                }
+
+                if (entry.Count >= MaxRequests)
+                {
+                    blocked = true;
+                }
+                else
+                {
+                    entry.Count++;
+                }
+            }
+
+            if (blocked)
+            {
+                context.Response.StatusCode = 429;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsJsonAsync(new { error = "Too many requests. Please try again later." });
+                return;
+            }
+        }
+
+        await this.next(context);
+    }
+
+    private static bool PathRequiresRateLimiting(string path)
+    {
+        foreach (var authPath in AuthPaths)
+        {
+            if (path.StartsWith(authPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private class RateLimitEntry
+    {
+        public DateTime WindowStart { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/Tickflo.Web/Program.cs
+++ b/Tickflo.Web/Program.cs
@@ -24,6 +24,7 @@ using Tickflo.Core.Services.Web;
 using Tickflo.Core.Services.Workspace;
 using Tickflo.Web;
 using Tickflo.Web.Authentication;
+using Tickflo.Web.Middleware;
 using Tickflo.Web.Realtime;
 using Tickflo.Web.Services;
 
@@ -237,6 +238,7 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+app.UseMiddleware<RateLimitMiddleware>();
 app.UseSession();
 
 app.UseAuthentication();


### PR DESCRIPTION
## Summary

2 security and architectural fixes.

### Fixes
- `#161` Custom in-memory rate limiting middleware that blocks auth endpoints (login, signup, forgot/reset/set password, email confirm, cron) at 10 req/min per IP. Returns 429 with JSON error.
- `#160` Updated `WorkspaceAccessService.EnsureWorkspaceAccessAsync` and `EnsureAdminAccessAsync` to throw `ForbiddenException` (403) instead of `UnauthorizedAccessException`, enabling proper HTTP mapping through the HttpExceptionMiddleware.

### Remaining
`#50, #51, #53` — major architectural refactors (test naming, ViewServices, Domain model)